### PR TITLE
Updated UI of Doc-to-Pdf page

### DIFF
--- a/Word-to-Pdf/index.html
+++ b/Word-to-Pdf/index.html
@@ -14,7 +14,7 @@
     <div id="navbar"></div>
     <section id="w2p">
         <input type="file" class="addfile"><br>
-        <button onclick="dwnldpdf()">Download pdf</button>
+        <button onclick="dwnldpdf()" id="dwpdf">Download pdf</button>
         <div class="pdf"> </div>
     </section>
 </body>

--- a/Word-to-Pdf/index.html
+++ b/Word-to-Pdf/index.html
@@ -7,12 +7,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Word-to-Pdf</title>
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="../css/homepage.css">
 </head>
 
 <body>
-    <input type="file" class="addfile"><br>
-    <button onclick="dwnldpdf()">Download pdf</button>
-    <div class="pdf"> </div>
+    <div id="navbar"></div>
+    <section id="w2p">
+        <input type="file" class="addfile"><br>
+        <button onclick="dwnldpdf()">Download pdf</button>
+        <div class="pdf"> </div>
+    </section>
 </body>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"
@@ -22,5 +26,6 @@
 <script src="https://cdn.jsdelivr.net/npm/mammoth@1.4.8/mammoth.browser.min.js"></script>
 
 <script src="script.js"></script>
+<script src="../js/script.js"></script>
 
 </html>

--- a/Word-to-Pdf/index.html
+++ b/Word-to-Pdf/index.html
@@ -6,15 +6,23 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Word-to-Pdf</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css"
+        integrity="sha512-Fo3rlrZj/k7ujTnHg4CGR2D7kSs0v4LLanw2qksYuRlEzO+tcaEPQogQ0KaoGN26/zrn20ImR1DfuLWnOo7aBA=="
+        crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="../css/homepage.css">
 </head>
 
 <body>
     <div id="navbar"></div>
+
     <section id="w2p">
-        <input type="file" class="addfile"><br>
-        <button onclick="dwnldpdf()" id="dwpdf">Download pdf</button>
+        <label for="addfile" class="custom-file-upload" id="addfilelab">
+            <i class="fa fa-cloud-upload"></i> Upload .doc file
+        </label>
+        <input type="file" id="addfile"><br>
+        <button id="dwpdf" disabled><i class="fa fa-download" aria-hidden="true"></i> Download
+            pdf</button>
         <div class="pdf"> </div>
     </section>
 </body>

--- a/Word-to-Pdf/index.html
+++ b/Word-to-Pdf/index.html
@@ -20,6 +20,8 @@
         <label for="addfile" class="custom-file-upload" id="addfilelab">
             <i class="fa fa-cloud-upload"></i> Upload .doc file
         </label>
+        <button id="reset"><i class="fas fa-undo"></i> Reset</button>
+        <br>
         <input type="file" id="addfile"><br>
         <button id="dwpdf" disabled><i class="fa fa-download" aria-hidden="true"></i> Download
             pdf</button>

--- a/Word-to-Pdf/script.js
+++ b/Word-to-Pdf/script.js
@@ -15,24 +15,27 @@ var opt = {
     jsPDF: { unit: 'in', format: 'a4', orientation: 'portrait' }
 };
 addfile.addEventListener('change', (e) => {
-    console.time();
-    var reader = new FileReader();
-    reader.onloadend = function (event) {
-        var arrayBuffer = reader.result;
-        mammoth.convertToHtml({ arrayBuffer: arrayBuffer }).then(function (resultObject) {
-            pdf.innerHTML = resultObject.value
-            console.log(resultObject.value)
-        })
-        console.timeEnd();
+    // addfile.files[0].name.substring(addfile.files[0].name.length - 4)
+    if (addfile.files[0].name.substring(addfile.files[0].name.length - 4) === 'docx') {
+        console.log(addfile.files[0].name.substring(addfile.files[0].name.length - 4));
+        console.time();
+        var reader = new FileReader();
+        reader.onloadend = function (event) {
+            var arrayBuffer = reader.result;
+            mammoth.convertToHtml({ arrayBuffer: arrayBuffer }).then(function (resultObject) {
+                pdf.innerHTML = resultObject.value
+                console.log(resultObject.value)
+            })
+            console.timeEnd();
+        }
+        reader.readAsArrayBuffer(addfile.files[0]);
+        pdf.style.display = 'none';
+        dwpdf.disabled = false;
+        if (addfile.value != null) {
+            addfilelab.innerHTML = '<i class="fa fa-check" aria-hidden="true" ></i> Uploaded .doc file';
+            addfilelab.style.pointerEvents = 'none';
+        }
     }
-    reader.readAsArrayBuffer(addfile.files[0]);
-    pdf.style.display = 'none';
-    dwpdf.disabled = false;
-    if (addfile.value != null) {
-        addfilelab.innerHTML = '<i class="fa fa-check" aria-hidden="true" ></i> Uploaded .doc file';
-        addfilelab.style.pointerEvents = 'none';
-    }
-
 })
 function dwnldpdf() {
     pdf.style.display = 'block';

--- a/Word-to-Pdf/script.js
+++ b/Word-to-Pdf/script.js
@@ -2,6 +2,8 @@ var addfile = document.querySelector("#addfile");
 var pdf = document.querySelector(".pdf");
 var dwpdf = document.querySelector('#dwpdf');
 var reset = document.querySelector('#reset');
+var addfilelab = document.querySelector('#addfilelab');
+
 
 
 var opt = {
@@ -26,6 +28,11 @@ addfile.addEventListener('change', (e) => {
     reader.readAsArrayBuffer(addfile.files[0]);
     pdf.style.display = 'none';
     dwpdf.disabled = false;
+    if (addfile.value != null) {
+        addfilelab.innerHTML = '<i class="fa fa-check" aria-hidden="true" ></i> Uploaded .doc file';
+        addfilelab.style.pointerEvents = 'none';
+    }
+
 })
 function dwnldpdf() {
     pdf.style.display = 'block';
@@ -47,4 +54,6 @@ dwpdf.addEventListener('mouseout', () => {
 reset.addEventListener('click', () => {
     addfile.value = null;
     dwpdf.disabled = true;
+    addfilelab.innerHTML = '<i class="fa fa-cloud-upload"></i> Upload .doc file';
+    addfilelab.style.pointerEvents = 'auto';
 })

--- a/Word-to-Pdf/script.js
+++ b/Word-to-Pdf/script.js
@@ -1,5 +1,7 @@
-var addfile = document.querySelector(".addfile");
+var addfile = document.querySelector("#addfile");
 var pdf = document.querySelector(".pdf");
+var dwpdf = document.querySelector('#dwpdf');
+
 var opt = {
     margin: 1,
     pagebreak: { mode: 'avoid-all' },
@@ -24,6 +26,7 @@ addfile.addEventListener('change', (e) => {
     }
     reader.readAsArrayBuffer(addfile.files[0]);
     pdf.style.display = 'none';
+    dwpdf.disabled = false;
 })
 
 
@@ -33,3 +36,12 @@ function dwnldpdf() {
     html2pdf().set(opt).from(pdf).save();
     setTimeout(() => { pdf.style.display = 'none'; }, 1);
 }
+dwpdf.addEventListener('click', dwnldpdf)
+dwpdf.addEventListener('mouseover', () => {
+    dwpdf.classList.add('dwpdf_hover');
+    dwpdf.style.backgroundColor = '#1f8036';
+})
+dwpdf.addEventListener('mouseout', () => {
+    dwpdf.style.backgroundColor = '#28a745';
+    dwpdf.classList.remove('dwpdf_hover');
+})

--- a/Word-to-Pdf/script.js
+++ b/Word-to-Pdf/script.js
@@ -1,6 +1,8 @@
 var addfile = document.querySelector("#addfile");
 var pdf = document.querySelector(".pdf");
 var dwpdf = document.querySelector('#dwpdf');
+var reset = document.querySelector('#reset');
+
 
 var opt = {
     margin: 1,
@@ -11,13 +13,10 @@ var opt = {
     jsPDF: { unit: 'in', format: 'a4', orientation: 'portrait' }
 };
 addfile.addEventListener('change', (e) => {
-
     console.time();
     var reader = new FileReader();
     reader.onloadend = function (event) {
         var arrayBuffer = reader.result;
-        // debugger
-
         mammoth.convertToHtml({ arrayBuffer: arrayBuffer }).then(function (resultObject) {
             pdf.innerHTML = resultObject.value
             console.log(resultObject.value)
@@ -28,14 +27,13 @@ addfile.addEventListener('change', (e) => {
     pdf.style.display = 'none';
     dwpdf.disabled = false;
 })
-
-
 function dwnldpdf() {
     pdf.style.display = 'block';
     console.log('Saving Pdf');
     html2pdf().set(opt).from(pdf).save();
     setTimeout(() => { pdf.style.display = 'none'; }, 1);
 }
+
 dwpdf.addEventListener('click', dwnldpdf)
 dwpdf.addEventListener('mouseover', () => {
     dwpdf.classList.add('dwpdf_hover');
@@ -44,4 +42,9 @@ dwpdf.addEventListener('mouseover', () => {
 dwpdf.addEventListener('mouseout', () => {
     dwpdf.style.backgroundColor = '#28a745';
     dwpdf.classList.remove('dwpdf_hover');
+})
+
+reset.addEventListener('click', () => {
+    addfile.value = null;
+    dwpdf.disabled = true;
 })

--- a/Word-to-Pdf/style.css
+++ b/Word-to-Pdf/style.css
@@ -7,8 +7,9 @@
     transform: translate(-50%, -50%);
     border: 2px solid black;
     border-radius: 10px;
-    padding: 36px;
+    padding: 48px 36px;
     background-color: rgba(173, 216, 230, 0.5);
+    font-weight: 600;
 }
 img {
     width: 90%;
@@ -22,8 +23,8 @@ img {
 }
 #dwpdf{
     border-radius: 18px;
-    padding: 6px;
-    font-size: 1em;
+    padding: 8px;
+    font-size: 1.2em;
     background-color: #28a745;
     border: 2px solid #1f8036;
     transition: all 0.2s;
@@ -48,5 +49,24 @@ img {
     background-color: #dc3545;
     border: 2px solid #880b18;
     cursor: pointer;
+}
+#reset:hover {
+  animation: shake 0.82s cubic-bezier(.36,.07,.19,.97) both;
+  transform: translate3d(0, 0, 0);
+  perspective: 1000px;
+}
 
+@keyframes shake {
+  10%, 90% {
+    transform: translate3d(-1px, 0, 0);
+  }
+  20%, 80% {
+    transform: translate3d(2px, 0, 0);
+  }
+  30%, 50%, 70% {
+    transform: translate3d(-4px, 0, 0);
+  }
+  40%, 60% {
+    transform: translate3d(4px, 0, 0);
+  }
 }

--- a/Word-to-Pdf/style.css
+++ b/Word-to-Pdf/style.css
@@ -1,13 +1,26 @@
 #w2p{
     text-align: center;
+    width: 36%;
     position: absolute;
     left: 50%;
     top: 50%;
     transform: translate(-50%, -50%);
+    border: 2px solid black;
+    border-radius: 10px;
+    padding: 36px;
+    background-color: rgba(173, 216, 230, 0.5);
 }
 img {
     width: 90%;
 }
 input{
-    padding-bottom: 7px;
+    padding-bottom: 28px;
+}
+#dwpdf{
+    border-radius: 7px;
+    padding: 5px;
+    font-size: 1em;
+    background-color: #28a745;
+    border: 2px solid #1f8036;
+
 }

--- a/Word-to-Pdf/style.css
+++ b/Word-to-Pdf/style.css
@@ -1,4 +1,4 @@
-body{
+#w2p{
     text-align: center;
     position: absolute;
     left: 50%;

--- a/Word-to-Pdf/style.css
+++ b/Word-to-Pdf/style.css
@@ -13,14 +13,30 @@
 img {
     width: 90%;
 }
-input{
+#addfile{
     padding-bottom: 28px;
+    display: none;
+}
+#addfilelab{
+    margin-bottom: 28px;
 }
 #dwpdf{
     border-radius: 7px;
-    padding: 5px;
+    padding: 6px;
     font-size: 1em;
     background-color: #28a745;
     border: 2px solid #1f8036;
-
+    transition: all 0.2s;
+    cursor: pointer;
+}
+.dwpdf_hover{
+    box-shadow: 0 0.7em 0.5em -0.4em #042e0d;
+    transform: scale(0.95);
+    cursor: pointer;
+}
+.custom-file-upload {
+    border: 1px solid #ccc;
+    display: inline-block;
+    padding: 6px 12px;
+    cursor: pointer;
 }

--- a/Word-to-Pdf/style.css
+++ b/Word-to-Pdf/style.css
@@ -21,7 +21,7 @@ img {
     margin-bottom: 28px;
 }
 #dwpdf{
-    border-radius: 7px;
+    border-radius: 18px;
     padding: 6px;
     font-size: 1em;
     background-color: #28a745;
@@ -39,4 +39,14 @@ img {
     display: inline-block;
     padding: 6px 12px;
     cursor: pointer;
+}
+#reset{
+    margin-left: 10%;
+    border-radius: 18px;
+    padding: 6px;
+    font-size: 1em;
+    background-color: #dc3545;
+    border: 2px solid #880b18;
+    cursor: pointer;
+
 }


### PR DESCRIPTION
Fixes #105


Here is the page:
![image](https://user-images.githubusercontent.com/72927422/148366426-3dfa0de9-e65a-4716-8fac-f6bc6acd399c.png)
Initially Download pdf button is disabled, user needs to click on **Upload .doc file** to select a doc file. 

After selecting the file, the page appears as (upload button is locked now, user may use reset to change the file):
![image](https://user-images.githubusercontent.com/72927422/148366758-ae996e56-c2b8-4552-8db0-f10e4d94cf0e.png)

Now user may click on **Download pdf**(enabled now) to download the pdf file.
![image](https://user-images.githubusercontent.com/72927422/148367146-1a3cb323-23e7-40c5-9263-ecb7e335cf8e.png)

At any stage, if user is not satisfied with the file uploaded, he may select reset button to redo the process from beginning.
![image](https://user-images.githubusercontent.com/72927422/148367584-b22a6b83-c0fb-400a-ba3e-5980ffb9135e.png)

Github page link: https://udith51.github.io/Student-portal/Word-to-Pdf/index.html
Do comment in case any update/change is required.

Participant Id: 1066