### PR TITLE
userdefined filename feature added in text to pdf tool

### DIFF
--- a/Text-to-pdf/index.html
+++ b/Text-to-pdf/index.html
@@ -20,6 +20,7 @@
 
   <div id="space"></div>
   <section id="t2p">
+    <input type="text" id="filename" placeholder="filename is required" maxlength="40"><span id="fname" style="padding: 3px;"></span>
     <textarea id="txtarea" name="text" placeholder="Enter Text Here"></textarea>
     <div id="btn">
       <button id="reset"><i class="fas fa-undo"></i> Reset</button>

--- a/Text-to-pdf/script.js
+++ b/Text-to-pdf/script.js
@@ -5,21 +5,39 @@
 var areaCv = document.getElementById('txtarea');
 var tTpButton = document.getElementById('convert');
 const textarea = document.querySelector("#txtarea");
-
+const filename = document.querySelector("#filename");
 
 function generateResume() {
     var doc = new jsPDF();
+    var file = document.getElementById('filename').value;
     var splitText = doc.splitTextToSize(areaCv.value, 180);
     doc.text(15, 20, splitText);
-    doc.save("text.pdf");
+    doc.save(file);
 }
 
 // When the button is clicked, it executes the three functions
 tTpButton.addEventListener('click', () => {
     generateResume();
 })
-// Auto Resize textarea
 
+filename.addEventListener("keyup",() =>{
+    if(validate() && filename.value){
+        document.getElementById("fname").style.color = "yellow";
+        document.getElementById("fname").innerHTML = "valid filename";
+        tTpButton.disabled = checktext();
+        tTpButton.style.pointerEvents = "auto";
+    }else if (filename.value == ""){
+        document.getElementById("fname").style.color = "yellow";
+        document.getElementById("fname").innerHTML = "fill the filename";
+    }else{
+        document.getElementById("fname").style.color = "black";
+        document.getElementById("fname").innerHTML = "invalid filename. filename should contain only letters and numbers";
+        tTpButton.disabled = true;
+        tTpButton.style.pointerEvents = "none";
+    }
+})
+
+// Auto Resize textarea
 const sizeReset = (e) => {
     textarea.style.height = "100px";
     let scHeight = e.target.scrollHeight;
@@ -28,7 +46,7 @@ const sizeReset = (e) => {
 textarea.addEventListener("keyup", sizeReset)
 textarea.addEventListener("keyup", () => {
     if (textarea.value) {
-        tTpButton.disabled = false;
+        tTpButton.disabled = checkfilename();
         tTpButton.style.pointerEvents = "auto";
     }
     else {
@@ -41,4 +59,35 @@ var reset = document.querySelector('#reset');
 reset.addEventListener('click', () => {
     textarea.value = "";
     textarea.style.height = "150px";
+    filename.value = "";
+    document.getElementById("fname").innerHTML = "";
 })
+
+// function for validating the filename
+function validate(){
+    var regex = /^[a-zA-Z0-9 ]+$/;
+    var name = filename.value;
+    if(regex.test(name)){
+        return true;
+    }else{
+        return false;
+    }
+}
+
+//function for checking the filename and to enable download button.
+function checkfilename(){
+    if(filename.value){
+        return false;
+    }else{
+        return true;
+    }
+}
+
+//function to check the textarea and to enable the download button.
+function checktext(){
+    if(textarea.value){
+        return false;
+    }else{
+        return true;
+    }
+}


### PR DESCRIPTION
## Thanks for your support to the project. Please check below mentioned points -


### What kind of change does this PR introduce ?

This PR introduces a new feature.  The feature is about giving use rdefined filename to the pdf u get to download from the Text-to-pdf tool.


### Documentation updated ?

No



### Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Links
check out the new feature in this link https://siva-krish45.github.io/Student-portal/Text-to-pdf/index.html

## Screenshots
intro page:

![image](https://user-images.githubusercontent.com/69798791/150757769-92a29005-7cba-4ec3-84d6-bc79ac93315b.png)

The file downloaded was **subjects.pdf** as mentioned in the filename input field.

![image](https://user-images.githubusercontent.com/69798791/150758185-a4cab1cc-4ef9-4710-bd0e-e80d5b35f318.png)

it also checks whether the filename is valid and gives an message

![image](https://user-images.githubusercontent.com/69798791/150758598-30479891-3a88-4448-aae8-7360fb5f8425.png)

download pdf button is only enabled when both the fields are non empty and valid.



